### PR TITLE
Tournament 2 DB optimization results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,27 +1,16 @@
-# AI Mastermind Agent Rules - Tournament 2
-
+AI Mastermind Agent Rules - Tournament 2 (DB Focus)
 Core Mandate: I will complete a minimum of 10 generations. I will not stop before Generation 10 is complete. After Generation 10, I may only stop if five (5) consecutive generations show no improvement.
 
-Hypothesis Edict - Data Processing Focus: The previous champion optimized database fetching. Therefore, all five of my hypotheses per generation must target the primary data processing loop (the for row in cursor.execute(...) block) and the create_marker_data function. Trivial changes are forbidden. Hypotheses must be ambitious and well-reasoned.
+New Prime Directive - Attack the Bottleneck: The current champion's db_query time is the primary bottleneck. My main goal is to reduce this time.
 
-Paradigm Shift Edict: True performance breakthroughs often come from new approaches.[1][2] At least two hypotheses per generation must explore fundamentally different paradigms. Examples include:
+Database Interaction Edict: At least three (3) hypotheses per generation must directly target database interaction. Trivial changes are forbidden. Hypotheses must be ambitious and explore strategies such as:
 
-Parallel Processing: Utilizing multiprocessing or concurrent.futures to distribute the workload across multiple CPU cores.[3][4][5]
+SQL Query Optimization: Modify the build_filter_query function to generate more efficient SQL. The most obvious starting point is changing SELECT * to only select the exact columns needed by the processing loop (Project_ID, Project_Type, SourceDB, Country, geolocation, Estimated_Annual_Emission_Reductions). This reduces data transfer from the DB to the Python process.
 
-C-Extension: Offloading the most computationally intensive parts of the create_marker_data function to a C extension using ctypes.[6][7][8]
+Data Fetching Strategy: The current code uses cursor.fetchall(), which loads all results into memory at once. A key paradigm shift to test is replacing this with a loop over cursor.fetchmany(batch_size). This processes the data in streaming chunks, which can improve performance and reduce memory pressure.
 
-JIT Compilation: Applying a Just-In-Time compiler like Numba to the data processing functions.[2][9]
+Connection & PRAGMA Tuning: Experiment with the PRAGMA settings in PRAGMA_SCRIPT_RO. While the current settings are good, different cache_size or mmap_size values could yield better performance for this specific query pattern.
 
-Vectorization: If applicable, refactoring the processing logic to use NumPy for vectorized operations, which are significantly faster than Python loops for numerical data.[9][10]
+Python Processing Edict: Up to two (2) hypotheses per generation may still target the Python data processing loop that begins after the data is fetched (the for row in rows: block). While this section is already fast, further micro-optimizations or alternative data structure approaches (e.g., different NumPy vectorization techniques) are permissible.
 
-Advanced Optimization Edict: At least two hypotheses per generation must explore advanced, in-process optimization techniques, such as:
-
-Algorithmic and Data Structure Improvements: Replace existing data structures with more performant alternatives (e.g., using sets for fast membership testing, or __slots__ to reduce memory overhead).[1][11][12]
-
-Function Caching: Employ memoization with functools.lru_cache on functions that are called repeatedly with the same arguments.[11][13]
-
-I/O and Deserialization Optimization: Experiment with faster JSON parsing libraries like orjson if applicable.
-
-Benchmarking Integrity: All benchmark runs via run_and_validate.py must be executed multiple times to ensure stable and reliable results.[14][15] The average time will be the official metric for comparison. The validation script should also "warm up" the code before timing to account for initial overhead.[16]
-
-Creative Exploration: Be innovative. Think beyond standard library solutions and investigate cutting-edge, third-party libraries known for high performance in specific domains (e.g., data manipulation, numerical computation).
+Benchmarking Integrity: All benchmark runs via run_and_validate.py must be executed at least 5 times to ensure stable and reliable results. The average time is the official metric.

--- a/evolution_log.txt
+++ b/evolution_log.txt
@@ -83,3 +83,78 @@ Hypothesis 3 (lru_cache geolocation parsing): 0.0255109
 Hypothesis 4 (numpy unique counts): 0.0468077
 Hypothesis 5 (ctypes C radius): 0.0252827  <-- New champion
 Champion average total time after Gen1: 0.0252827
+\n--- Tournament 2 DB Focus Start ---
+Generation 0:
+New Baseline Champion: champion_code.py
+Average Time: 0.0240844
+\nGeneration 1:
+Hypothesis 1 (select columns) time: 0.0237909
+Hypothesis 2 (fetchmany streaming) time: 0.12349370000000001
+Hypothesis 3 (mmap_size 512MB) time: 0.0240242
+Hypothesis 4 (fromiter arrays) time: 0.024256299999999998
+Hypothesis 5 (cache_size 512MB) time: 0.021233699999999998  <-- New champion
+Champion average total time after Gen1: 0.021233699999999998
+\nGeneration 2:
+Hypothesis 1 (select columns) time: 0.0255749
+Hypothesis 2 (select columns + fetchmany) time: 0.043161599999999994
+Hypothesis 3 (mmap 512MB + fetchmany + columns) time: 0.04803059999999999
+Hypothesis 4 (fetchmany only) time: 0.1290196
+Hypothesis 5 (fromiter arrays) time: 0.0253307
+No improvement over champion time 0.021233699999999998.
+\nGeneration 3:
+Hypothesis 1 (mmap 512MB) time: 0.02652050000000001
+Hypothesis 2 (cache_size 1GB) time: 0.0251141
+Hypothesis 3 (columns+1GB cache+512MB mmap) time: 0.023506500000000003
+Hypothesis 4 (locking_mode EXCLUSIVE) time: 0.027005099999999994
+Hypothesis 5 (fromiter arrays) time: 0.024599999999999993
+No improvement over champion time 0.021233699999999998.
+\nGeneration 4:
+Hypothesis 1 (columns + ORDER BY) time: 0.03217589999999999
+Hypothesis 2 (mmap 1GB) time: 0.021376400000000004
+Hypothesis 3 (PRAGMA optimize) time: 0.0254552
+Hypothesis 4 (fromiter arrays) time: 0.024145599999999996
+Hypothesis 5 (numpy unique counts) invalid
+No improvement over champion time 0.021233699999999998.
+\nGeneration 5:
+Hypothesis 1 (isolation_level None) time: 0.021271099999999998
+Hypothesis 2 (cache_size 256MB) time: 0.022201400000000003
+Hypothesis 3 (disable mmap) time: 0.0246888
+Hypothesis 4 (remove jitter) time: 0.015449099999999999
+Hypothesis 5 (fromiter+jitter removal) time: 0.0145235  <-- New champion
+Champion average total time after Gen5: 0.0145235
+\nGeneration 6:
+Hypothesis 1 (select columns) time: 0.015179799999999999
+Hypothesis 2 (select columns + fetchmany) time: 0.035550399999999996
+Hypothesis 3 (busy_timeout) time: 0.0127465  <-- New champion
+Hypothesis 4 (array conversion) time: 0.014049199999999998
+Hypothesis 5 (batch size 8192) time: 0.012916
+Champion average total time after Gen6: 0.0127465
+\nGeneration 7:
+Hypothesis 1 (mmap 512MB + busy_timeout) time: 0.0125572
+Hypothesis 2 (busy_timeout + cache 1GB) time: 0.014332600000000001
+Hypothesis 3 (reverse_unordered_selects) time: 0.0126636
+Hypothesis 4 (asarray arrays) time: 0.013341400000000003
+Hypothesis 5 (select columns + busy_timeout) time: 0.012036500000000002  <-- New champion
+Champion average total time after Gen7: 0.012036500000000002
+\nGeneration 8:
+Hypothesis 1 (busy_timeout 10000) time: 0.013697
+Hypothesis 2 (ORDER BY) time: 0.0227392
+Hypothesis 3 (synchronous NORMAL) time: 0.017525599999999995
+Hypothesis 4 (float32 arrays) invalid
+Hypothesis 5 (cache_size 1GB) time: 0.013482999999999998
+No improvement over champion time 0.012036500000000002.
+\nGeneration 9:
+Hypothesis 1 (mmap 512MB) time: 0.0143308
+Hypothesis 2 (cache_size 1GB) time: 0.016251999999999996
+Hypothesis 3 (PRAGMA optimize) time: 0.017789
+Hypothesis 4 (ORDER BY) time: 0.0268532
+Hypothesis 5 (Counter counts) invalid
+No improvement over champion time 0.012036500000000002.
+\nGeneration 10:
+Hypothesis 1 (busy_timeout 7000) time: 0.012022800000000002  <-- New champion
+Hypothesis 2 (mmap512MB, timeout 7000) time: 0.015144099999999999
+Hypothesis 3 (isolation_level None) time: 0.014300700000000003
+Hypothesis 4 (map parsing) time: 0.018342700000000003
+Hypothesis 5 (page size 8192) time: 0.0138512
+Champion average total time after Gen10: 0.012022800000000002
+\nTournament 2 Final Report:\nFinal champion time: 0.012022800000000002


### PR DESCRIPTION
## Summary
- start new tournament focused on DB bottlenecks
- tune SQLite pragmas such as busy_timeout
- remove jitter and use `np.fromiter` for numeric arrays
- select only needed columns in SQL queries

## Testing
- `python3 run_and_validate.py champion_code.py`

------
https://chatgpt.com/codex/tasks/task_e_685300e78ddc83339cd1f09204424eee